### PR TITLE
fix: non-DRDY operation failure

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "AFE_NXP_Arduino"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.0.2
+PROJECT_NUMBER         = 2.0.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AFE_NXP_Arduino
-version=2.0.2
+version=2.0.3
 author=Tedd OKANO
 maintainer=Tedd OKANO
 sentence=Class library for NXP Analog Front End

--- a/src/AFE_NXP.cpp
+++ b/src/AFE_NXP.cpp
@@ -169,7 +169,10 @@ int AFE_base::wait_conversion_complete( double wait )
 {
 	if ( 0 < wait )
 	{
-		delayMicroseconds( wait * delay_accuracy * 1e6 );
+		if ( wait < 0.016 )
+			delayMicroseconds( wait * delay_accuracy * 1e6 );
+		else
+			delay( wait * delay_accuracy * 1e3 );			
 		return	0;
 	}
 


### PR DESCRIPTION
fixed by handling to use `delay()` instead of `delayMicroseconds()` of the waining time is 0.016 seconds or longer.